### PR TITLE
added copy URL to history page

### DIFF
--- a/ui/src/app/(pages)/(protected)/history/page.tsx
+++ b/ui/src/app/(pages)/(protected)/history/page.tsx
@@ -143,6 +143,7 @@ function HistoryPage() {
         apiBaseURL + '/download' + '/' + uploadId + '?user_id=' + user['$id'],
       )
       if (!downloadResponse.ok) {
+        setDownloading(false)
         toast.dismiss()
         toast.error('Upload ID is not valid')
         return
@@ -184,6 +185,11 @@ function HistoryPage() {
         setDownloading(false)
       }
     }
+  }
+
+  const handleCopyShareLink = async(uploadId: string) => {
+    const shareURL = process.env.NEXT_PUBLIC_APP_URL + '/share/' + uploadId
+    await navigator.clipboard.writeText(shareURL)
   }
 
   const handleDelete = async (uploadId: string) => {
@@ -308,6 +314,11 @@ function HistoryPage() {
                 disabled={downloading}
               >
                 Download
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => handleCopyShareLink(row.original.id)}
+              >
+                Copy URL
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem


### PR DESCRIPTION
## What does this PR do?

This add a Copy URL option in the dropdown in history page

## Issue

Fixes #83 

## What changed?

- added option that copies the share link to clipboard

## Why these changes?

- To enable easy copying the share URL from the history page
- Its a feature

## Is it tested?

Yes, tested locally

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/ambujraj/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.