### PR TITLE
added autodownload on scanning QR

### DIFF
--- a/middleware/app/main.py
+++ b/middleware/app/main.py
@@ -349,7 +349,7 @@ def post_upload_return_link_qr(
         box_size=10,
         border=4,
     )
-    qr.add_data(file_url)
+    qr.add_data(file_url + '?autodownload=true')
     qr.make(fit=True)
 
     img = qr.make_image(fill_color="black", back_color="white")

--- a/ui/src/app/(pages)/share/[uploadId]/page.tsx
+++ b/ui/src/app/(pages)/share/[uploadId]/page.tsx
@@ -8,6 +8,7 @@ import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
 import { DownloadIcon } from '@radix-ui/react-icons'
 import { lookup } from 'mime-types'
+import { useSearchParams } from 'next/navigation'
 import {
   ColumnDef,
   VisibilityState,
@@ -65,6 +66,11 @@ function SharePage({ params }: Params) {
   const [data, setData] = React.useState<File[]>([])
   const [source, setSource] = useState(null)
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
+
+  const searchParams = useSearchParams()
+ 
+  const autodownload = searchParams.get('autodownload')
+
   useEffect(() => {
     const fetchData = async () => {
       const apiBaseURL = process.env.NEXT_PUBLIC_API_BASE_URL
@@ -105,6 +111,9 @@ function SharePage({ params }: Params) {
         setData((prevdata) => [...prevdata, file])
       }
       setIsLoading(false)
+      if(autodownload){
+        handleDownloadAll()
+      }
     }
     if (isMounted) {
       fetchData()


### PR DESCRIPTION
## What does this PR do?

Added autodownload on scanning QR code.

## Issue

Fixes #122 

## What changed?

- Added query param of autodownload in QR link
- On autodownload=true, automatically downloading files on page load.

## Why these changes?

- To make it quick download in scanning QR
- Its an improvement.

## Is it tested?

No, need to test locally

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/ambujraj/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.