### PR TITLE
Fixed header alignment breaking on smaller mobile screen for logged out users

### DIFF
--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -90,7 +90,7 @@ export const Header = ({ authorised, statusLoaded, name, email }) => {
             ByteShare
           </span>
         </Button>
-        <div className="flex md:order-2 space-x-3 md:space-x-0 rtl:space-x-reverse">
+        <div className="flex md:order-2 space-x-2 md:space-x-0 rtl:space-x-reverse">
           {statusLoaded ? (
             <Button
               variant="ghost"


### PR DESCRIPTION
## What does this PR do?

Fixed the header breaking in smaller mobile screens.

## Issue

Fixes #132 

## What changed?

- Changed the space-x-3 to space-x-2

## Why these changes?

- Decreased the space between the component
- It was a bug fix.

## Is it tested?

Yes, locally

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/ambujraj/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.