### PR TITLE
Add batch upload in UI and backend

### DIFF
--- a/ui/src/components/loading.tsx
+++ b/ui/src/components/loading.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from 'react'
+import { Label } from '@/components/ui/label'
+
+const LoadingText = ({text}) => {
+  const [dots, setDots] = useState('')
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setDots((prevDots) => {
+        if (prevDots.length >= 3) {
+          return ''
+        } else {
+          return prevDots + '.'
+        }
+      })
+    }, 500)
+
+    return () => clearInterval(intervalId)
+  }, [])
+
+  return <Label>{text}{dots}</Label>
+}
+
+export default LoadingText


### PR DESCRIPTION
## What does this PR do?

Added Batch upload reducing multiple API calls to 2 calls per upload.

## Issue

Fixes #136 

## What changed?

- Added batch upload endpoint in backend
- Added batch upload support in UI
- Added loading text for initialising and processing text

## Why these changes?

- To save API calls
- It's an improvement

## Is it tested?

Yes, locally

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/ambujraj/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.