### PR TITLE
added loading toast for inprogress tasks

### DIFF
--- a/ui/src/app/(pages)/(protected)/history/page.tsx
+++ b/ui/src/app/(pages)/(protected)/history/page.tsx
@@ -140,7 +140,7 @@ function HistoryPage() {
   const handleDownload = async (uploadId: string) => {
     if (!downloading) {
       setDownloading(true)
-      toast.info('Download in progress...', { duration: 9999999 })
+      toast.loading('Download in progress...', { duration: 9999999 })
       const apiBaseURL = process.env.NEXT_PUBLIC_API_BASE_URL
       const apiKey = process.env.NEXT_PUBLIC_API_KEY
 
@@ -237,6 +237,7 @@ function HistoryPage() {
   const handleEditTitle = async(event) => {
     event.preventDefault()
     if(!editing){
+      toast.loading('Edit in progress...', { duration: 9999999 })
       setEditing(true)
       setOpenEditDialog(false)
 
@@ -272,14 +273,16 @@ function HistoryPage() {
             })
             setData(updatedData)
           }
+          toast.dismiss()
           toast.success('Successfully updated.')
         }
       } catch (err){
-        
+        toast.dismiss()
       } finally {
         setNewTitle('')
         setEditing(false)
         setNewTitleUploadID('')
+        
       }
   }
     

--- a/ui/src/app/(pages)/share/[uploadId]/page.tsx
+++ b/ui/src/app/(pages)/share/[uploadId]/page.tsx
@@ -130,7 +130,7 @@ function SharePage({ params }: Params) {
   ) => {
     try {
       setDownloadingOne(true)
-      toast.info('Download in progress...', { duration: 9999999 })
+      toast.loading('Download in progress...', { duration: 9999999 })
       const response = await fetch(downloadLink)
       const blob = await response.blob()
       saveAs(blob, fileName)


### PR DESCRIPTION
## What does this PR do?

Added loading toast for all inprogress tasks till its in progress.

## Issue

Fixes #167 

## What changed?

- Added toast.loading in edit title
- Updated existing toast that denote in progress tasks

## Why these changes?

- To give feedback to user once they start longer progress.
- It's an user experience enhancement.

## Is it tested?

Yes, locally

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/ambujraj/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.
