### PR TITLE
Enabled multi download in history and share page

### DIFF
--- a/ui/src/app/(pages)/(protected)/history/page.tsx
+++ b/ui/src/app/(pages)/(protected)/history/page.tsx
@@ -72,7 +72,6 @@ function HistoryPage() {
   const [newTitleUploadID, setNewTitleUploadID] = useState('')
   const [editing, setEditing] = useState(false)
   const [data, setData] = React.useState<History[]>([])
-  const [downloading, setDownloading] = useState(false)
   const [openEditDialog, setOpenEditDialog] = useState(false)
   const [openDeleteConfirmation, setOpenDeleteConfirmation] = useState(false)
   const [deleteUploadID, setDeleteUploadID] = useState('')
@@ -157,8 +156,6 @@ function HistoryPage() {
   }, [statusLoaded])
 
   const handleDownload = async (uploadId: string) => {
-    if (!downloading) {
-      setDownloading(true)
       const downloadInprogressToastID = toast.loading('Download in progress...', { duration: 9999999 })
       const apiBaseURL = process.env.NEXT_PUBLIC_API_BASE_URL
       const apiKey = process.env.NEXT_PUBLIC_API_KEY
@@ -174,7 +171,7 @@ function HistoryPage() {
         },
       )
       if (!downloadResponse.ok) {
-        setDownloading(false)
+        
         toast.dismiss(downloadInprogressToastID)
         toast.error('Upload ID is not valid')
         return
@@ -207,15 +204,14 @@ function HistoryPage() {
 
         const zipBlob = await zip.generateAsync({ type: 'blob' })
         const zipFileName = 'ByteShare_Preview_' + uploadId + '.zip'
+        
         saveAs(zipBlob, zipFileName)
         toast.dismiss(downloadInprogressToastID)
       } catch (err) {
         toast.dismiss(downloadInprogressToastID)
         toast.error('Error downloading zip file.')
-      } finally {
-        setDownloading(false)
       }
-    }
+    
   }
 
   const handleCopyShareLink = async(uploadId: string) => {
@@ -411,7 +407,6 @@ function HistoryPage() {
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => handleDownload(row.original.id)}
-                disabled={downloading}
               >
                 Download
               </DropdownMenuItem>

--- a/ui/src/app/(pages)/auth/login/components/auth-form.tsx
+++ b/ui/src/app/(pages)/auth/login/components/auth-form.tsx
@@ -69,7 +69,6 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
               Email
             </Label>
             <Input
-              className="text-lightgray-foreground"
               id="email"
               placeholder="Email address"
               type="email"
@@ -87,7 +86,6 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
               Password
             </Label>
             <Input
-              className="text-lightgray-foreground"
               id="password"
               placeholder="Password"
               type="password"

--- a/ui/src/app/(pages)/auth/signup/components/auth-form.tsx
+++ b/ui/src/app/(pages)/auth/signup/components/auth-form.tsx
@@ -81,7 +81,6 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
               Name
             </Label>
             <Input
-              className="text-lightgray-foreground"
               id="name"
               placeholder="Your Name"
               type="text"
@@ -98,7 +97,6 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
               Email
             </Label>
             <Input
-              className="text-lightgray-foreground"
               id="email"
               placeholder="Email Address"
               type="email"
@@ -116,7 +114,6 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
               Email
             </Label>
             <Input
-              className="text-lightgray-foreground"
               id="password"
               placeholder="Password"
               type="password"

--- a/ui/src/app/(pages)/share/[uploadId]/page.tsx
+++ b/ui/src/app/(pages)/share/[uploadId]/page.tsx
@@ -62,7 +62,6 @@ function SharePage({ params }: Params) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [progress, setProgress] = useState(0)
   const [downloadingAll, setDownloadingAll] = useState(false)
-  const [downloadingOne, setDownloadingOne] = useState(false)
   const [data, setData] = React.useState<File[]>([])
   const [source, setSource] = useState(null)
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
@@ -129,18 +128,17 @@ function SharePage({ params }: Params) {
     downloadLink: string,
     fileName: string,
   ) => {
+    const downloadInprogressToastID = toast.loading('Download in progress...', {
+      duration: 9999999,
+    })
     try {
-      setDownloadingOne(true)
-      toast.loading('Download in progress...', { duration: 9999999 })
       const response = await fetch(downloadLink)
       const blob = await response.blob()
       saveAs(blob, fileName)
-      toast.dismiss()
     } catch (err) {
-      toast.dismiss()
       toast.error('Error in downloading file')
     } finally {
-      setDownloadingOne(false)
+      toast.dismiss(downloadInprogressToastID)
     }
   }
 
@@ -178,7 +176,6 @@ function SharePage({ params }: Params) {
           <Button
             variant="ghost"
             className="h-8 w-8 p-0"
-            disabled={downloadingOne}
             onClick={() => {
               handleSingleDownload(row.original.downloadLink, row.original.name)
             }}


### PR DESCRIPTION
## What does this PR do?

Enabling milti download at same time in History and share page

## Issue

Fixes #189 

## What changed?

- Removed disabling of download button
- Removed lightgrey of inputs in auth page

## Why these changes?

- To enable multi download

## Is it tested?

Yes, locally

## Checklist

- [x] I have read through the [Contributing Guidelines](https://github.com/ambujraj/byteshare/blob/master/CONTRIBUTING.md)
- [x] I have also updated the dependent codes as well and README.md if applicable
- [x] My code adheres to consistent formatting standards and includes clear comments where necessary to enhance readability and understanding.
